### PR TITLE
Use the latest tinydb distribution in requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ gnupg==2.0.2
 pyperclip==1.5.9
 PyYAML==3.11
 tabulate==0.7.5
-tinydb==2.3.1
+tinydb==2.3.1.post2


### PR DESCRIPTION
Unable to install package via setuptools, e.g. `python setup.py install` because of bad tinydb distribution (as per msiemens/tinydb#51).

```shell
$ python setup.py install
...
Processing dependencies for passpie==0.1
Searching for tinydb==2.3.1
Reading https://pypi.python.org/simple/tinydb/
Best match: tinydb 2.3.1
Downloading https://pypi.python.org/packages/source/t/tinydb/tinydb-2.3.1.zip#md5=ff22ef7166f471ec3e5077b43b76bf46
Processing tinydb-2.3.1.zip
Writing /var/folders/9w/v7xf8cyx1xs7hxhkv1gs64tc0000gn/T/easy_install-VFNBAt/tinydb-2.3.1/setup.cfg
Running tinydb-2.3.1/setup.py -q bdist_egg --dist-dir /var/folders/9w/v7xf8cyx1xs7hxhkv1gs64tc0000gn/T/easy_install-VFNBAt/tinydb-2.3.1/egg-dist-tmp-MnAega
No eggs found in /var/folders/9w/v7xf8cyx1xs7hxhkv1gs64tc0000gn/T/easy_install-VFNBAt/tinydb-2.3.1/egg-dist-tmp-MnAega (setup script problem?)
error: Could not find required distribution tinydb==2.3.1
```

Small workaround for this issue.