### PR TITLE
Improve cli complete

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,6 +360,7 @@ Add this line to your ~/.config/fish/config.fish
 ```
 if which passpie > /dev/null 2>&1; eval (passpie complete | tr '\n' ';'); end
 ```
+<!-- Keep an eye on: https://github.com/fish-shell/fish-shell/issues/159 -->
 
 #### zsh
 

--- a/README.md
+++ b/README.md
@@ -343,14 +343,14 @@ example.com  fake     *****
 
 You can activate passpie completion for `bash` or `zsh` shells
 
-> Check the generated script with `passpie complete {shell_name}`.
+> Check the generated script with `passpie complete`.
 
 #### bash
 
 Add this line to your .bash_profile or .bashrc
 
 ```
-if which passpie > /dev/null; then eval "$(passpie complete bash)"; fi
+if which passpie > /dev/null; then eval "$(passpie complete)"; fi
 ```
 
 #### fish
@@ -358,7 +358,7 @@ if which passpie > /dev/null; then eval "$(passpie complete bash)"; fi
 Add this line to your ~/.config/fish/config.fish
 
 ```
-if which passpie > /dev/null 2>&1; eval (passpie complete fish | tr '\n' ';'); end
+if which passpie > /dev/null 2>&1; eval (passpie complete | tr '\n' ';'); end
 ```
 
 #### zsh
@@ -366,7 +366,7 @@ if which passpie > /dev/null 2>&1; eval (passpie complete fish | tr '\n' ';'); e
 Add this line to your .zshrc or .zpreztorc
 
 ```
-if which passpie > /dev/null; then eval "$(passpie complete zsh)"; fi
+if which passpie > /dev/null; then eval "$(passpie complete)"; fi
 ```
 
 ### Configuring passpie with `.passpierc`

--- a/passpie/cli.py
+++ b/passpie/cli.py
@@ -139,7 +139,8 @@ def cli(ctx, database, verbose):
 
 
 @cli.command(help='Shows completion scripts')
-@click.argument('shell_name', type=click.Choice(completion.SHELLS))
+@click.argument('shell_name', type=click.Choice(completion.SHELLS),
+                default=None, required=False)
 @click.option('--commands', default=None)
 def complete(shell_name, commands):
     commands = ['add', 'copy', 'remove', 'search', 'update']

--- a/passpie/completion.py
+++ b/passpie/completion.py
@@ -1,3 +1,8 @@
+import os
+
+from psutil import Process
+
+
 BASH = """
 function _passpie()
 {
@@ -77,6 +82,11 @@ SHELLS = ['zsh', 'fish', 'bash']
 
 
 def script(shell_name, config_path, commands):
+    if not shell_name:
+        try:
+            shell_name = Process(os.getpid()).parent().name()
+        except TypeError:
+            shell_name = Process(os.getpid()).parent.name
     text = ''
     if shell_name == 'zsh':
         text = ZSH.replace('{commands}', '\n'.join(commands))

--- a/passpie/completion.py
+++ b/passpie/completion.py
@@ -23,15 +23,15 @@ complete -F _passpie 'passpie'
 """
 
 FISH = """
-function __fish_passpie_credentials
+function _passpie_credentials
   grep -EhriIo '[A-Z0-9._%+-]+@[A-Z0-9.-]+(@[A-Z0-9_\-\.]+)?' {config_path}
 end
 
-function __fish_passpie_credential_names
+function _passpie_credential_names
   ls -1 {config_path}
 end
 
-function __fish_passpie_needs_command
+function _passpie_needs_command
   set cmd (commandline -opc)
   if [ (count $cmd) -eq 1 -a $cmd[1] = 'passpie' ]
     return 0
@@ -39,7 +39,7 @@ function __fish_passpie_needs_command
   return 1
 end
 
-function __fish_passpie_using_command
+function _passpie_using_command
   set cmd (commandline -opc)
   if [ (count $cmd) -gt 1 ]
     for arg in $argv
@@ -51,9 +51,9 @@ function __fish_passpie_using_command
   return 1
 end
 
-complete -f -c passpie -n '__fish_passpie_needs_command' -a '{commands}' --description 'Manage a credential'
-complete -f -c passpie -n '__fish_passpie_using_command {commands}' -a '(__fish_passpie_credentials)
-                                                                        (__fish_passpie_credential_names)' --description 'Credential'
+complete -f -c passpie -n '_passpie_needs_command' -a '{commands}' --description 'Manage a credential'
+complete -f -c passpie -n '_passpie_using_command {commands}' -a '(_passpie_credentials)
+                                                                  (_passpie_credential_names)' --description 'Credential'
 """
 
 ZSH = """

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,8 @@ requirements = [
     'PyYAML==3.11',
     'tabulate==0.7.5',
     'tinydb==2.3.2',
-    'GitPython==1.0.1'
+    'GitPython==1.0.1',
+    'psutil==3.0.1',
 ]
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -455,6 +455,37 @@ def test_cli_complete_chooses_prints_nothing_when_not_supported(mocker):
     assert mock_click.echo.called is True
 
 
+def test_cli_complete_guesses_shell_when_no_shell_provided__psutil_2(mocker):
+    mock_click = mocker.patch('passpie.cli.click')
+    BASH = 'function _passpie()...'
+    mocker.patch.multiple('passpie.completion', BASH=BASH)
+    mock_proc = mocker.patch('passpie.completion.Process')
+    mock_proc.return_value.parent.return_value.name.return_value = 'bash'
+
+    runner = CliRunner()
+    result = runner.invoke(cli.complete)
+
+    assert result.exit_code == 0
+    assert mock_click.echo.called is True
+    mock_click.echo.assert_called_with(BASH)
+
+
+def test_cli_complete_guesses_shell_when_no_shell_provided__psutil_1(mocker):
+    mock_click = mocker.patch('passpie.cli.click')
+    BASH = 'function _passpie()...'
+    mocker.patch.multiple('passpie.completion', BASH=BASH)
+    mock_proc = mocker.patch('passpie.completion.Process')
+    mock_proc.return_value.parent.side_effect = TypeError
+    mock_proc.return_value.parent.name = 'bash'
+
+    runner = CliRunner()
+    result = runner.invoke(cli.complete)
+
+    assert result.exit_code == 0
+    assert mock_click.echo.called is True
+    mock_click.echo.assert_called_with(BASH)
+
+
 def test_update_password_from_prompt_encrypts_password(mocker, mock_cryptor, mock_db):
     credential = {
         'fullname': 'foo@bar',

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -13,6 +13,18 @@ def test_script_returns_zsh_script_when_zsh_shell_name(mocker):
         assert line in text
 
 
+def test_script_returns_fish_script_when_fish_shell_name(mocker):
+    shell_name = 'fish'
+    config_path = '/tmp'
+    commands = ['add', 'remove', 'update', 'remove', 'search']
+    text = completion.script(shell_name=shell_name,
+                             config_path=config_path,
+                             commands=commands)
+
+    for line in completion.FISH.split('\n')[9:28]:
+        assert line in text
+
+
 def test_script_returns_bash_script_when_bash_shell_name(mocker):
     shell_name = 'bash'
     config_path = '/tmp'


### PR DESCRIPTION
How about auto detecting the running shell? The `shell_name` argument is still parsed in order to maintain compatibility with already existing complete lines in `~/.bashrc`, `~/.config/fish/config.fish` and `~/.zshrc` files.

Also, I had to add `psutil==3.0.1` to the requirements to make it available in `pypy`. I'm not sure if we should fix it to 3.0.1, what do you think? Some systems use old 1.x versions and they're already supported (check [completion.py:88](https://github.com/marcwebbie/passpie/commit/c102f6986592e113f4a972729161e033d3dad201#diff-6684e287c05691360ddb6a44e38b2f82R88)).

Besides that, this also proposes some fixes and tests, as you can see in the commits.

Hope it's all good. Please review and comment :smiley: 