### PR TITLE
Default to an empty dict instead of None

### DIFF
--- a/passpie/cli.py
+++ b/passpie/cli.py
@@ -58,7 +58,7 @@ class AliasGroup(click.Group):
 
     def get_command(self, ctx, name):
         cmd = super(AliasGroup, self).get_command(ctx, name)
-        aliases = ctx.params.get('configuration', {}).get('aliases')
+        aliases = ctx.params.get('configuration', {}).get('aliases', {})
         if cmd:
             return cmd
         elif name in aliases:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -153,6 +153,12 @@ class CliTests(object):
             assert credential['login'] in output
             assert credential['comment'] in output
 
+    def test_cli_show_error_no_such_command(self, mocker, mock_config, irunner):
+        with mock_config():
+            result = irunner.invoke(cli.cli, ['nocommand'])
+            assert result.exit_code == 2
+            assert 'Error: No such command "nocommand"' in result.output
+
 
 class CliAddTests(object):
 


### PR DESCRIPTION
This avoids the following failure:

```
⋊> passpie help add
Traceback (most recent call last):
...
TypeError: argument of type 'NoneType' is not iterable
```

~~@marcwebbie: can you please help me write a test to this?~~ Test added 😉 