### PR TITLE
Fix an issue with gpg2 (v2.1) where it does not respect --passphrase

### DIFF
--- a/passpie/config.py
+++ b/passpie/config.py
@@ -5,7 +5,7 @@ import re
 
 import yaml
 
-from .utils import tempdir
+from .utils import tempdir, setup_gpg_confs, which
 from .crypt import ensure_keys, import_keys, get_default_recipient
 
 
@@ -66,6 +66,8 @@ def setup_crypt(configuration):
     keys_filepath = ensure_keys(configuration['path'])
     if keys_filepath:
         configuration['homedir'] = tempdir()
+        if which('gpg2'):
+            setup_gpg_confs(configuration['homedir'])
         import_keys(keys_filepath, configuration['homedir'])
     if not configuration['recipient']:
         configuration['recipient'] = get_default_recipient(configuration['homedir'])

--- a/passpie/utils.py
+++ b/passpie/utils.py
@@ -49,3 +49,13 @@ def tempdir():
 def touch(path):
     with open(path, "w"):
         pass
+
+
+def setup_gpg_confs(path):
+    gpg_conf = os.path.join(path, 'gpg.conf')
+    agent_conf = os.path.join(path, 'gpg-agent.conf')
+
+    with open(gpg_conf, "w") as f:
+        f.write("pinentry-mode loopback\n")
+    with open(agent_conf, "w") as f:
+        f.write("allow-loopback-pinentry\n")


### PR DESCRIPTION
gpg2.1 will not use passphrase at command line due to the started
gpg-agent not respecting the option without setting:

gpg.conf:pinentry-mode loopback
gpg-agent.conf:allow-loopback-pinentry

This results in the default pinentry program popping up after typing
passphrase at passpie prompt (or even garbage).

Further this leaves an idle gpg-agent around that is not addressed by
this commit.

ref:
https://bugs.g10code.com/gnupg/issue1772
https://wiki.archlinux.org/index.php/GnuPG#Unattended_passphrase