### PR TITLE
Add message indicating how long the password will live in the clipboard

### DIFF
--- a/passpie/clipboard.py
+++ b/passpie/clipboard.py
@@ -30,6 +30,7 @@ def ensure_commands(commands):
 
 
 def clean(command, delay):
+    print('Password copied to clipboard. Waiting for {}s to clear clipboard'.format(delay))
     for dot in ['.' for _ in range(delay)]:
         sys.stdout.write(dot)
         sys.stdout.flush()


### PR DESCRIPTION
Having an indication of how long we are going to wait before clearing the clipboard is useful to know before you go and copy another piece of data to your clipboard, only to lose it x amount of seconds later.