### PR TITLE
Verify proc return code while checking for errors

### DIFF
--- a/passpie/process.py
+++ b/passpie/process.py
@@ -45,4 +45,4 @@ def call(*args, **kwargs):
             error = error.decode('utf-8')
         except AttributeError:
             pass
-        return output, error
+        return output, error or proc.returncode != 0

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -65,3 +65,18 @@ def test_call_output_and_error_doesnt_decode_in_case_of_unicode(mocker, mock_pop
 
     assert result_output == output
     assert result_error == error
+
+
+def test_call_error_true_on_non_zero_status(mocker, mock_popen):
+    MockProc = mocker.patch('passpie.process.Proc')
+    output = mocker.MagicMock()
+    error = mocker.MagicMock()
+    output.decode.return_value = ''
+    error.decode.return_value = ''
+    MockProc().__enter__.return_value.communicate.return_value = (output, error)
+    MockProc().__enter__.return_value.returncode = 2
+
+    result_output, result_error = call(['echo', 'hello'])
+
+    assert result_output == ''
+    assert result_error == True


### PR DESCRIPTION
As `stderr` is set do `DEVNULL` on most usages, no error is captured and it's always an empty string. Better look into [child return code](https://docs.python.org/3.6/library/subprocess.html#subprocess.Popen.returncode) too.

This fixes an issue similar to #114 for me.