### PR TITLE
Use curl to download `get-pip.py` overcoming SSL errors

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,7 +8,7 @@ init:
   - "ECHO %PYTHON%"
   - ps: "ls C:/Python*"
 install:
-  - ps: (new-object net.webclient).DownloadFile('https://bootstrap.pypa.io/get-pip.py', 'C:/get-pip.py')
+  - "curl -fsS -o C:/get-pip.py https://bootstrap.pypa.io/get-pip.py"
   - "%PYTHON%/python.exe C:/get-pip.py"
   - "%PYTHON%/Scripts/pip.exe install setuptools"
   - "%PYTHON%/Scripts/pip.exe install -r requirements/test.txt"


### PR DESCRIPTION
This fixes the AppVeyor build.